### PR TITLE
otherLicenseでも0x0cを取り除くよう修正

### DIFF
--- a/Sources/LicensePlistMerger.swift
+++ b/Sources/LicensePlistMerger.swift
@@ -158,7 +158,7 @@ extension LicensesPlistMerger {
             guard let licenseURL,
                   let body = String(data: try Data(contentsOf: licenseURL), encoding: .utf8) else { return nil }
 
-            return LicenseInfo(name: directoryURL.lastPathComponent, body: body)
+            return LicenseInfo(name: directoryURL.lastPathComponent, body: body.replacingOccurrences(of: "\u{0c}", with: ""))
         } catch {
             print(error)
             return nil


### PR DESCRIPTION
以下の処理がotherLicenseのとき漏れていたので修正

https://github.com/ubiregiinc/LicensePlistsMerger/blob/0bc0a29429f234dae5165c1efde066015e53aac4/Sources/LicensePlistMerger.swift#L118-L119